### PR TITLE
Sodium Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,10 +43,6 @@ group = project.maven_group
 repositories {
 	maven { url "https://maven.terraformersmc.com/" }
 	maven {
-		name "flashyreesesRepositoryReleases"
-		url "https://maven.flashyreese.me/releases"
-	}
-	maven {
 		url = "https://api.modrinth.com/maven"
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,13 @@ group = project.maven_group
 
 repositories {
 	maven { url "https://maven.terraformersmc.com/" }
+	maven {
+		name "flashyreesesRepositoryReleases"
+		url "https://maven.flashyreese.me/releases"
+	}
+	maven {
+		url = "https://api.modrinth.com/maven"
+	}
 }
 
 dependencies {
@@ -64,6 +71,13 @@ dependencies {
 		exclude(group: "net.fabricmc.fabric-api")
 		exclude(group: "net.fabricmc.fabric-loader")
 	}
+
+
+
+
+	// Sodium Stuff
+
+	modApi "maven.modrinth:sodium:mc${project.sodium_version}"
 }
 
 loom {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,7 @@ org.gradle.jvmargs=-Xmx1G
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 	fabric_version=0.83.0+1.20.1
 	modmenu_version=7.0.1
+    sodium_version=1.20-0.4.10
 
 # Publishing metadata
     curseforge_id=310205

--- a/src/main/java/link/infra/borderlessmining/config/ConfigStorage.java
+++ b/src/main/java/link/infra/borderlessmining/config/ConfigStorage.java
@@ -1,0 +1,22 @@
+package link.infra.borderlessmining.config;
+
+import me.jellysquid.mods.sodium.client.gui.options.storage.OptionStorage;
+
+public class ConfigStorage implements OptionStorage<ConfigHandler> {
+    private final ConfigHandler config;
+
+    public ConfigStorage() {
+        this.config = ConfigHandler.getInstance();
+    }
+
+    @Override
+    public ConfigHandler getData() {
+        return this.config;
+    }
+
+
+    @Override
+    public void save() {
+        this.config.save();
+    }
+}

--- a/src/main/java/link/infra/borderlessmining/config/SodiumCompat.java
+++ b/src/main/java/link/infra/borderlessmining/config/SodiumCompat.java
@@ -1,0 +1,88 @@
+package link.infra.borderlessmining.config;
+
+import com.google.common.collect.ImmutableList;
+import me.jellysquid.mods.sodium.client.gui.options.*;
+import me.jellysquid.mods.sodium.client.gui.options.control.Control;
+import me.jellysquid.mods.sodium.client.gui.options.control.ControlValueFormatter;
+import me.jellysquid.mods.sodium.client.gui.options.control.SliderControl;
+import me.jellysquid.mods.sodium.client.gui.options.control.TickBoxControl;
+import net.minecraft.client.resource.language.I18n;
+import net.minecraft.text.Text;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.glfw.GLFW;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SodiumCompat {
+    public static final ConfigStorage configStorage = new ConfigStorage();
+
+
+    public static OptionPage config() {
+        List<OptionGroup> groups = new ArrayList<OptionGroup>();
+
+        groups.add(OptionGroup.createBuilder()
+                .add(OptionImpl.createBuilder(boolean.class, configStorage)
+                        .setName(Text.translatable("config.borderlessmining.general.enabled"))
+                        .setTooltip(Text.translatable("config.borderlessmining.general.enabled.tooltip"))
+                        .setControl(TickBoxControl::new)
+                        .setBinding(ConfigHandler::setEnabledPending, ConfigHandler::isEnabled)
+                        .build())
+                .add(OptionImpl.createBuilder(boolean.class, configStorage)
+                        .setName(Text.translatable("config.borderlessmining.general.videomodeoption"))
+                        .setTooltip(Text.translatable("config.borderlessmining.general.videomodeoption.tooltip"))
+                        .setControl(TickBoxControl::new)
+                        .setBinding((opt, value) -> opt.addToVanillaVideoSettings = value, (opt) -> opt.addToVanillaVideoSettings)
+                        .build())
+                .add(OptionImpl.createBuilder(boolean.class, configStorage)
+                        .setName(Text.translatable("config.borderlessmining.general.enabledmac"))
+                        .setTooltip(Text.translatable("config.borderlessmining.general.enabledmac.tooltip"))
+                        .setControl(TickBoxControl::new)
+                        .setBinding((opt, value) -> opt.enableMacOS = value, (opt) -> opt.enableMacOS)
+                        .build())
+                .build());
+
+        // monitors are not listed because of the way sodium works. will implement later
+
+        groups.add(OptionGroup.createBuilder()
+                .add(OptionImpl.createBuilder(boolean.class, configStorage)
+                        .setName(Text.translatable("config.borderlessmining.dimensions"))
+                        .setTooltip(Text.empty())
+                        .setControl(TickBoxControl::new)
+                        .setBinding((opt, val) -> opt.customWindowDimensions = opt.customWindowDimensions.setEnabled(true), (opt) -> opt.customWindowDimensions.enabled)
+                        .build())
+                .add(OptionImpl.createBuilder(boolean.class, configStorage)
+                        .setName(Text.translatable("config.borderlessmining.dimensions.monitorcoordinates"))
+                        .setTooltip(Text.translatable("config.borderlessmining.dimensions.monitorcoordinates.tooltip"))
+                        .setControl(TickBoxControl::new)
+                        .setBinding((opt, val) -> opt.customWindowDimensions = opt.customWindowDimensions.setUseMonitorCoordinates(true), (opt) -> opt.customWindowDimensions.useMonitorCoordinates)
+                        .build())
+                .add(OptionImpl.createBuilder(int.class, configStorage)
+                        .setName(Text.translatable("config.borderlessmining.dimensions.x"))
+                        .setTooltip(Text.empty())
+                        .setControl(option -> new SliderControl(option, 0, 9999, 1, ControlValueFormatter.number()))
+                        .setBinding((opt, val) -> opt.customWindowDimensions = opt.customWindowDimensions.setX(val), (opt) -> opt.customWindowDimensions.x)
+                        .build())
+                .add(OptionImpl.createBuilder(int.class, configStorage)
+                        .setName(Text.translatable("config.borderlessmining.dimensions.y"))
+                        .setTooltip(Text.empty())
+                        .setControl(option -> new SliderControl(option, 0, 9999, 1, ControlValueFormatter.number()))
+                        .setBinding((opt, val) -> opt.customWindowDimensions = opt.customWindowDimensions.setY(val), (opt) -> opt.customWindowDimensions.y)
+                        .build())
+                .add(OptionImpl.createBuilder(int.class, configStorage)
+                        .setName(Text.translatable("config.borderlessmining.dimensions.width"))
+                        .setTooltip(Text.empty())
+                        .setControl(option -> new SliderControl(option, 0, 9999, 1, ControlValueFormatter.number()))
+                        .setBinding((opt, val) -> opt.customWindowDimensions = opt.customWindowDimensions.setWidth(val), (opt) -> opt.customWindowDimensions.width)
+                        .build())
+                .add(OptionImpl.createBuilder(int.class, configStorage)
+                        .setName(Text.translatable("config.borderlessmining.dimensions.height"))
+                        .setTooltip(Text.empty())
+                        .setControl(option -> new SliderControl(option, 0, 9999, 1, ControlValueFormatter.number()))
+                        .setBinding((opt, val) -> opt.customWindowDimensions = opt.customWindowDimensions.setHeight(val), (opt) -> opt.customWindowDimensions.height)
+                        .build())
+                .build());
+
+        return new OptionPage(Text.translatable("config.borderlessmining.title"), ImmutableList.copyOf(groups));
+    }
+}

--- a/src/main/java/link/infra/borderlessmining/mixin/SodiumOptionsMixin.java
+++ b/src/main/java/link/infra/borderlessmining/mixin/SodiumOptionsMixin.java
@@ -1,0 +1,26 @@
+package link.infra.borderlessmining.mixin;
+
+import link.infra.borderlessmining.config.SodiumCompat;
+import me.jellysquid.mods.sodium.client.gui.SodiumOptionsGUI;
+import me.jellysquid.mods.sodium.client.gui.options.OptionPage;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+@Mixin(value = SodiumOptionsGUI.class, remap = false)
+public class SodiumOptionsMixin {
+    @Shadow
+    @Final
+    private List<OptionPage> pages;
+
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void init(CallbackInfo info) {
+        this.pages.add(SodiumCompat.config());
+    }
+}

--- a/src/main/resources/borderlessmining.mixins.json
+++ b/src/main/resources/borderlessmining.mixins.json
@@ -2,12 +2,11 @@
   "required": true,
   "package": "link.infra.borderlessmining.mixin",
   "compatibilityLevel": "JAVA_17",
-  "mixins": [
-  ],
   "client": [
 	  "FullScreenOptionMixin",
 	  "VideoModeFixMixin",
-	  "WindowMixin"
+	  "WindowMixin",
+      "SodiumOptionsMixin"
   ],
   "injectors": {
     "defaultRequire": 1,


### PR DESCRIPTION
Adds a page to Sodium's video settings that allows modifying of most (read below) settings in the Mod Menu config.

Due to the way sodium's options work, there are no things like input boxes, but rather things like sliders. For this reason, things like the choosing the monitor are not available in the settings, as that would require building a custom option, and Sodium's documentation on this are little to none (I worked off looking at other mods that have Sodium compatibility).

I thought about adding in the full screen resolution option in, but since that is a vanilla option, sodium could implement this in the future, and so I decided to hold off on adding it.