### PR TITLE
Sodium Compat (updated)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.2.+'
+	id 'fabric-loom' version '1.5.+'
 	id 'maven-publish'
 
 	id "com.github.breadmoirai.github-release" version "2.4.1"
@@ -42,6 +42,13 @@ group = project.maven_group
 
 repositories {
 	maven { url "https://maven.terraformersmc.com/" }
+	maven {
+		name "flashyreesesRepositoryReleases"
+		url "https://maven.flashyreese.me/releases"
+	}
+	maven {
+		url = "https://api.modrinth.com/maven"
+	}
 }
 
 dependencies {
@@ -64,6 +71,8 @@ dependencies {
 		exclude(group: "net.fabricmc.fabric-api")
 		exclude(group: "net.fabricmc.fabric-loader")
 	}
+
+	modApi "maven.modrinth:sodium:mc${project.sodium_version}"
 }
 
 loom {

--- a/build.gradle
+++ b/build.gradle
@@ -43,10 +43,6 @@ group = project.maven_group
 repositories {
 	maven { url "https://maven.terraformersmc.com/" }
 	maven {
-		name "flashyreesesRepositoryReleases"
-		url "https://maven.flashyreese.me/releases"
-	}
-	maven {
 		url = "https://api.modrinth.com/maven"
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
     loader_version=0.15.3
 
 # Mod Properties
-	mod_version = 1.1.10
+	mod_version = 1.1.11
 	maven_group = link.infra.borderlessmining
 	archives_base_name = borderless-mining
 
@@ -16,6 +16,7 @@ org.gradle.jvmargs=-Xmx1G
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
 	fabric_version=0.91.3+1.20.4
 	modmenu_version=9.0.0
+	sodium_version=1.20.2-0.5.5
 
 # Publishing metadata
     curseforge_id=310205

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/link/infra/borderlessmining/config/ConfigStorage.java
+++ b/src/main/java/link/infra/borderlessmining/config/ConfigStorage.java
@@ -1,0 +1,22 @@
+package link.infra.borderlessmining.config;
+
+import me.jellysquid.mods.sodium.client.gui.options.storage.OptionStorage;
+
+public class ConfigStorage implements OptionStorage<ConfigHandler> {
+    private final ConfigHandler config;
+
+    public ConfigStorage() {
+        this.config = ConfigHandler.getInstance();
+    }
+
+    @Override
+    public ConfigHandler getData() {
+        return this.config;
+    }
+
+
+    @Override
+    public void save() {
+        this.config.save();
+    }
+}

--- a/src/main/java/link/infra/borderlessmining/config/SodiumCompat.java
+++ b/src/main/java/link/infra/borderlessmining/config/SodiumCompat.java
@@ -1,0 +1,88 @@
+package link.infra.borderlessmining.config;
+
+import com.google.common.collect.ImmutableList;
+import me.jellysquid.mods.sodium.client.gui.options.*;
+import me.jellysquid.mods.sodium.client.gui.options.control.Control;
+import me.jellysquid.mods.sodium.client.gui.options.control.ControlValueFormatter;
+import me.jellysquid.mods.sodium.client.gui.options.control.SliderControl;
+import me.jellysquid.mods.sodium.client.gui.options.control.TickBoxControl;
+import net.minecraft.client.resource.language.I18n;
+import net.minecraft.text.Text;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.glfw.GLFW;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SodiumCompat {
+    public static final ConfigStorage configStorage = new ConfigStorage();
+
+
+    public static OptionPage config() {
+        List<OptionGroup> groups = new ArrayList<OptionGroup>();
+
+        groups.add(OptionGroup.createBuilder()
+                .add(OptionImpl.createBuilder(boolean.class, configStorage)
+                        .setName(Text.translatable("config.borderlessmining.general.enabled"))
+                        .setTooltip(Text.translatable("config.borderlessmining.general.enabled.tooltip"))
+                        .setControl(TickBoxControl::new)
+                        .setBinding(ConfigHandler::setEnabledPending, ConfigHandler::isEnabled)
+                        .build())
+                .add(OptionImpl.createBuilder(boolean.class, configStorage)
+                        .setName(Text.translatable("config.borderlessmining.general.videomodeoption"))
+                        .setTooltip(Text.translatable("config.borderlessmining.general.videomodeoption.tooltip"))
+                        .setControl(TickBoxControl::new)
+                        .setBinding((opt, value) -> opt.addToVanillaVideoSettings = value, (opt) -> opt.addToVanillaVideoSettings)
+                        .build())
+                .add(OptionImpl.createBuilder(boolean.class, configStorage)
+                        .setName(Text.translatable("config.borderlessmining.general.enabledmac"))
+                        .setTooltip(Text.translatable("config.borderlessmining.general.enabledmac.tooltip"))
+                        .setControl(TickBoxControl::new)
+                        .setBinding((opt, value) -> opt.enableMacOS = value, (opt) -> opt.enableMacOS)
+                        .build())
+                .build());
+
+        // monitors are not listed because of the way sodium works. will implement later
+
+        groups.add(OptionGroup.createBuilder()
+                .add(OptionImpl.createBuilder(boolean.class, configStorage)
+                        .setName(Text.translatable("config.borderlessmining.dimensions"))
+                        .setTooltip(Text.empty())
+                        .setControl(TickBoxControl::new)
+                        .setBinding((opt, val) -> opt.customWindowDimensions = opt.customWindowDimensions.setEnabled(true), (opt) -> opt.customWindowDimensions.enabled)
+                        .build())
+                .add(OptionImpl.createBuilder(boolean.class, configStorage)
+                        .setName(Text.translatable("config.borderlessmining.dimensions.monitorcoordinates"))
+                        .setTooltip(Text.translatable("config.borderlessmining.dimensions.monitorcoordinates.tooltip"))
+                        .setControl(TickBoxControl::new)
+                        .setBinding((opt, val) -> opt.customWindowDimensions = opt.customWindowDimensions.setUseMonitorCoordinates(true), (opt) -> opt.customWindowDimensions.useMonitorCoordinates)
+                        .build())
+                .add(OptionImpl.createBuilder(int.class, configStorage)
+                        .setName(Text.translatable("config.borderlessmining.dimensions.x"))
+                        .setTooltip(Text.empty())
+                        .setControl(option -> new SliderControl(option, 0, 9999, 1, ControlValueFormatter.number()))
+                        .setBinding((opt, val) -> opt.customWindowDimensions = opt.customWindowDimensions.setX(val), (opt) -> opt.customWindowDimensions.x)
+                        .build())
+                .add(OptionImpl.createBuilder(int.class, configStorage)
+                        .setName(Text.translatable("config.borderlessmining.dimensions.y"))
+                        .setTooltip(Text.empty())
+                        .setControl(option -> new SliderControl(option, 0, 9999, 1, ControlValueFormatter.number()))
+                        .setBinding((opt, val) -> opt.customWindowDimensions = opt.customWindowDimensions.setY(val), (opt) -> opt.customWindowDimensions.y)
+                        .build())
+                .add(OptionImpl.createBuilder(int.class, configStorage)
+                        .setName(Text.translatable("config.borderlessmining.dimensions.width"))
+                        .setTooltip(Text.empty())
+                        .setControl(option -> new SliderControl(option, 0, 9999, 1, ControlValueFormatter.number()))
+                        .setBinding((opt, val) -> opt.customWindowDimensions = opt.customWindowDimensions.setWidth(val), (opt) -> opt.customWindowDimensions.width)
+                        .build())
+                .add(OptionImpl.createBuilder(int.class, configStorage)
+                        .setName(Text.translatable("config.borderlessmining.dimensions.height"))
+                        .setTooltip(Text.empty())
+                        .setControl(option -> new SliderControl(option, 0, 9999, 1, ControlValueFormatter.number()))
+                        .setBinding((opt, val) -> opt.customWindowDimensions = opt.customWindowDimensions.setHeight(val), (opt) -> opt.customWindowDimensions.height)
+                        .build())
+                .build());
+
+        return new OptionPage(Text.translatable("config.borderlessmining.sodium"), ImmutableList.copyOf(groups));
+    }
+}

--- a/src/main/java/link/infra/borderlessmining/mixin/SodiumOptionsMixin.java
+++ b/src/main/java/link/infra/borderlessmining/mixin/SodiumOptionsMixin.java
@@ -1,0 +1,26 @@
+package link.infra.borderlessmining.mixin;
+
+import link.infra.borderlessmining.config.SodiumCompat;
+import me.jellysquid.mods.sodium.client.gui.SodiumOptionsGUI;
+import me.jellysquid.mods.sodium.client.gui.options.OptionPage;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+@Mixin(value = SodiumOptionsGUI.class, remap = false)
+public class SodiumOptionsMixin {
+    @Shadow
+    @Final
+    private List<OptionPage> pages;
+
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void init(CallbackInfo info) {
+        this.pages.add(SodiumCompat.config());
+    }
+}

--- a/src/main/resources/assets/borderlessmining/lang/en_us.json
+++ b/src/main/resources/assets/borderlessmining/lang/en_us.json
@@ -1,6 +1,7 @@
 {
   "text.borderlessmining.videomodename": "Borderless Windowed",
   "config.borderlessmining.title": "Borderless Mining Configuration",
+  "config.borderlessmining.sodium": "Windowed",
   "config.borderlessmining.general": "General",
   "config.borderlessmining.general.enabled": "Borderless Fullscreen",
   "config.borderlessmining.general.enabled.tooltip": "Switches to a borderless fullscreen window when Fullscreen is turned on",

--- a/src/main/resources/assets/borderlessmining/lang/fr_fr.json
+++ b/src/main/resources/assets/borderlessmining/lang/fr_fr.json
@@ -1,6 +1,7 @@
 {
   "text.borderlessmining.videomodename": "Fenêtré sans bordure",
   "config.borderlessmining.title": "Configuration de Borderless Mining",
+  "config.borderlessmining.sodium": "Fenêtré",
   "config.borderlessmining.general": "Général",
   "config.borderlessmining.general.enabled": "Fenêtré sans bordure",
   "config.borderlessmining.general.enabled.tooltip": "Passe en fenêtré sans bordure quand le plein écran est activé.",

--- a/src/main/resources/assets/borderlessmining/lang/it_it.json
+++ b/src/main/resources/assets/borderlessmining/lang/it_it.json
@@ -1,6 +1,7 @@
 {
   "text.borderlessmining.videomodename": "Schermo intero in finestra",
   "config.borderlessmining.title": "Impostazioni Borderless Mining",
+  "config.borderlessmining.sodium": "Finestra",
   "config.borderlessmining.general": "Generali",
   "config.borderlessmining.general.enabled": "Schermo intero senza bordi",
   "config.borderlessmining.general.enabled.tooltip": "Passa a una finestra a schermo intero senza bordi quando è attiva l'opzione schermo intero",

--- a/src/main/resources/assets/borderlessmining/lang/ko_kr.json
+++ b/src/main/resources/assets/borderlessmining/lang/ko_kr.json
@@ -1,6 +1,7 @@
 {
   "text.borderlessmining.videomodename": "Borderless Windowed",
   "config.borderlessmining.title": "Borderless Mining 환경 설정",
+  "config.borderlessmining.sodium": "Windowed",
   "config.borderlessmining.general": "일반",
   "config.borderlessmining.general.enabled": "테두리 없는 전체 화면",
   "config.borderlessmining.general.enabled.tooltip": "전체 화면 상태일 때 테두리가 없는 전체 화면으로 전환홥니다.",

--- a/src/main/resources/assets/borderlessmining/lang/pl_pl.json
+++ b/src/main/resources/assets/borderlessmining/lang/pl_pl.json
@@ -1,6 +1,7 @@
 {
   "text.borderlessmining.videomodename": "Okno bez krawędzi",
   "config.borderlessmining.title": "Konfiguracja Borderless Mining",
+  "config.borderlessmining.sodium": "Okno",
   "config.borderlessmining.general": "Ogólne",
   "config.borderlessmining.general.enabled": "Pełny ekran bez krawędzi",
   "config.borderlessmining.general.enabled.tooltip": "Przełącza na pełny ekran bez krawędzi, gdy pełny ekran jest włączony",

--- a/src/main/resources/assets/borderlessmining/lang/pt_br.json
+++ b/src/main/resources/assets/borderlessmining/lang/pt_br.json
@@ -1,6 +1,7 @@
 {
     "text.borderlessmining.videomodename": "Janela sem Brdas",
     "config.borderlessmining.title": "Borderless Mining Configuração",
+    "config.borderlessmining.sodium": "Janela",
     "config.borderlessmining.general": "Geral",
     "config.borderlessmining.general.enabled": "Tela cheia sem Bordas",
     "config.borderlessmining.general.enabled.tooltip": "Muda para uma janela de tela cheia sem bordas quando a tela cheia está ativada",

--- a/src/main/resources/assets/borderlessmining/lang/ru_ru.json
+++ b/src/main/resources/assets/borderlessmining/lang/ru_ru.json
@@ -1,6 +1,7 @@
 {
   "text.borderlessmining.videomodename": "Безрамочный режим",
   "config.borderlessmining.title": "Настройки Borderless Mining",
+  "config.borderlessmining.sodium": "Окно",
   "config.borderlessmining.general": "Основные",
   "config.borderlessmining.general.enabled": "Безрамочный полноэкранный режим",
   "config.borderlessmining.general.enabled.tooltip": "Переключение в режим безрамочного окна при разворачивании на полный экран",

--- a/src/main/resources/assets/borderlessmining/lang/tr_tr.json
+++ b/src/main/resources/assets/borderlessmining/lang/tr_tr.json
@@ -1,6 +1,7 @@
 {
   "text.borderlessmining.videomodename": "Kenarsız Pencere Modu",
   "config.borderlessmining.title": "Borderless Mining Ayarları",
+  "config.borderlessmining.sodium": "Pencere",
   "config.borderlessmining.general": "Genel",
   "config.borderlessmining.general.enabled": "Kenarsız Tam Ekran",
   "config.borderlessmining.general.enabled.tooltip": "Oyun tam ekrandayken, kenarsız pencere modu olarak değiştirir",

--- a/src/main/resources/assets/borderlessmining/lang/uk_ua.json
+++ b/src/main/resources/assets/borderlessmining/lang/uk_ua.json
@@ -1,6 +1,7 @@
 {
   "text.borderlessmining.videomodename": "Вікно без рамки",
   "config.borderlessmining.title": "Параметри Borderless Mining",
+  "config.borderlessmining.sodium": "Вікно",
   "config.borderlessmining.general": "Загальні",
   "config.borderlessmining.general.enabled": "Повноекранний без рамки",
   "config.borderlessmining.general.enabled.tooltip": "Увімкнути повноекранне вікно без рамки при розгортанні на весь екран",

--- a/src/main/resources/assets/borderlessmining/lang/zh_cn.json
+++ b/src/main/resources/assets/borderlessmining/lang/zh_cn.json
@@ -1,6 +1,7 @@
 {
   "text.borderlessmining.videomodename": "全屏无边框窗口",
   "config.borderlessmining.title": "Borderless Mining 配置",
+  "config.borderlessmining.sodium": "窗户",
   "config.borderlessmining.general": "通用",
   "config.borderlessmining.general.enabled": "全屏无边框窗口",
   "config.borderlessmining.general.enabled.tooltip": "开启全屏时切换到全屏无边框窗口",

--- a/src/main/resources/assets/borderlessmining/lang/zh_tw.json
+++ b/src/main/resources/assets/borderlessmining/lang/zh_tw.json
@@ -1,6 +1,7 @@
 {
   "text.borderlessmining.videomodename": "無邊框視窗",
   "config.borderlessmining.title": "無邊框挖礦設定",
+  "config.borderlessmining.sodium": "窗戶",
   "config.borderlessmining.general": "一般",
   "config.borderlessmining.general.enabled": "無邊框全螢幕",
   "config.borderlessmining.general.enabled.tooltip": "當開啟全螢幕時切換成無邊框全螢幕",

--- a/src/main/resources/borderlessmining.mixins.json
+++ b/src/main/resources/borderlessmining.mixins.json
@@ -2,12 +2,11 @@
   "required": true,
   "package": "link.infra.borderlessmining.mixin",
   "compatibilityLevel": "JAVA_17",
-  "mixins": [
-  ],
   "client": [
-	  "FullScreenOptionMixin",
-	  "VideoModeFixMixin",
-	  "WindowMixin"
+    "FullScreenOptionMixin",
+    "VideoModeFixMixin",
+    "WindowMixin",
+    "SodiumOptionsMixin"
   ],
   "injectors": {
     "defaultRequire": 1,


### PR DESCRIPTION
99% of the credit goes to @NulledBird _(I wasn't able to fork his repo to file the PR)_

Changes from #80:
- Updated some<i>(required)</i> dependencies.
- `Borderless Mining Configuration` --> `Windowed`, in Sodium, to fix clutter, especially in Reese's Sodium Options, covering half of the screen! _(also, most of the translations for `config.borderlessmining.sodium` should be correct)_