### PR TITLE
Support for Minecraft versions 1.20.5 and 1.20.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,15 @@
 plugins {
-	id 'fabric-loom' version '1.2.+'
+	id 'fabric-loom' version '1.6-SNAPSHOT'
 	id 'maven-publish'
 
-	id "com.github.breadmoirai.github-release" version "2.4.1"
-	id "org.ajoberstar.grgit" version "4.1.0"
-	id "com.modrinth.minotaur" version "2.+"
+	id "com.github.breadmoirai.github-release" version "2.5.2+"
+	id "org.ajoberstar.grgit" version "5.2.2+"
+	id "com.modrinth.minotaur" version "2.8.7+"
 	id "com.matthewprenger.cursegradle" version "1.4.0"
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = JavaVersion.VERSION_21
+targetCompatibility = JavaVersion.VERSION_21
 
 String getGitVersion(Project project) {
 	if (grgit != null) {
@@ -85,8 +85,8 @@ tasks.withType(JavaCompile).configureEach {
 	// If Javadoc is generated, this must be specified in that task too.
 	it.options.encoding = "UTF-8"
 
-	// Minecraft 1.18 (1.18-pre2) upwards uses Java 17.
-	it.options.release = 17
+	// Minecraft 1.20.5 upwards uses Java 21.
+	it.options.release = 21
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,19 +3,20 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-    minecraft_version=1.20.4
-    yarn_mappings=1.20.4+build.3
-    loader_version=0.15.3
+    minecraft_version=1.20.6
+    yarn_mappings=1.20.6+build.1
+    loader_version=0.15.11
 
 # Mod Properties
-	mod_version = 1.1.10
+	mod_version = 1.1.11
 	maven_group = link.infra.borderlessmining
 	archives_base_name = borderless-mining
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.91.3+1.20.4
-	modmenu_version=9.0.0
+	fabric_version=0.99.0+1.20.6
+    # TODO: Have to depend on the beta version of mod menu for now, until it gets updated as release.
+	modmenu_version=10.0.0-beta.1
 
 # Publishing metadata
     curseforge_id=310205

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/link/infra/borderlessmining/config/ConfigScreen.java
+++ b/src/main/java/link/infra/borderlessmining/config/ConfigScreen.java
@@ -58,8 +58,8 @@ public abstract class ConfigScreen extends Screen {
 			return 400;
 		}
 
-		protected int getScrollbarPositionX() {
-			return super.getScrollbarPositionX() + 32;
+		protected int getScrollbarX() {
+			return super.getScrollbarX() + 32;
 		}
 
 		public Style getHoveredStyle(int mouseX, int mouseY) {
@@ -121,7 +121,7 @@ public abstract class ConfigScreen extends Screen {
 
 	@Override
 	public void renderBackground(DrawContext context, int mouseX, int mouseY, float delta) {
-		this.renderBackgroundTexture(context);
+		this.renderBackgroundTexture(context, Screen.MENU_BACKGROUND_TEXTURE, 0, 0, 0.0F, 0.0F, this.width, this.height);
 	}
 
 	public abstract void addElements();

--- a/src/main/resources/borderlessmining.mixins.json
+++ b/src/main/resources/borderlessmining.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "link.infra.borderlessmining.mixin",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
   ],
   "client": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,6 +34,6 @@
   "depends": {
     "fabricloader": ">=0.15.11",
     "fabric-resource-loader-v0": "*",
-    "minecraft": "~1.20.5"
+    "minecraft": ["1.20.5", "1.20.6"]
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -32,8 +32,8 @@
   "accessWidener": "borderlessmining.accesswidener",
 
   "depends": {
-    "fabricloader": ">=0.7.2",
+    "fabricloader": ">=0.15.11",
     "fabric-resource-loader-v0": "*",
-    "minecraft": "~1.20.2"
+    "minecraft": "~1.20.5"
   }
 }


### PR DESCRIPTION
When updating, I mainly focused on the latter version, but it is compatible with 1.20.5 as well. Given that 1.20.6 is just a simple bug fix version, I don't think this will cause any problems.

If there are any reasons as to why there were some old version requirements in the build.gradle/gradle.properties, please lmk!